### PR TITLE
update to Coq after 8.11: Simon Boulier's plugin is now part of Coq

### DIFF
--- a/coq/BreadthFirst.v
+++ b/coq/BreadthFirst.v
@@ -3,12 +3,9 @@ Simon Boulier (INRIA) for the part before the def. of γ (without the simple lem
 Ralph Matthes (IRIT - CNRS and Univ. of Toulouse) for the three different methods of verification, all suggested in 1995 and for the forest-based verification and new system view found in 2018
 
 occasional references are made to the paper "Martin Hofmann’s case for non-strictly positive
-data types" by U. Berger, R. Matthes and A. Setzer, to appear in LIPIcs vol. 130 (TYPES 2018 post-proceedings)
+data types" by U. Berger, R. Matthes and A. Setzer, in LIPIcs vol. 130 (TYPES 2018 post-proceedings), https://doi.org/10.4230/LIPIcs.TYPES.2018.1
 
 *)
-
-From TypingFlags Require Import Loader.
-
 
 Inductive tree :=
 | leaf : nat -> tree
@@ -102,11 +99,11 @@ Definition breadthfirst_spec t := flatten (niv t).
 Compute (niv ex1).
 Compute (breadthfirst_spec ex1).
 
-Unset Guard Checking.
+Unset Positivity Checking.
 Inductive Rou :=
 | Over : Rou
 | Next : ((Rou -> list nat) -> list nat) -> Rou.
-Set Guard Checking.
+Set Positivity Checking.
 
 Definition unfoldRou (c : Rou) (k : Rou -> list nat) : list nat :=
   match c with
@@ -218,12 +215,14 @@ Print Assumptions MH_Verif.
 Definition isextractor (R: Rou -> list(list nat) -> Prop)(ll: list(list nat))(k:Rou -> list nat): Prop :=
     forall (c: Rou)(ll1: list(list nat)), R c ll1 -> k c = flatten(zip ll ll1).
 
-Unset Guard Checking.
+Unset Positivity Checking.
 Inductive rep: Rou -> list (list nat) -> Prop :=
 | overrep: rep Over []
 | nextrep: forall (f: (Rou -> list nat) -> list nat)(l: list nat)(ll: list(list nat)), (forall (k: Rou -> list nat)(ll': list(list nat)), isextractor rep ll' k -> f k = l ++ flatten(zip ll' ll)) -> rep (Next f) (l::ll).
 (** is a non-strictly positive inductive proposition - could equivalently be defined impredicatively thanks to impredicativity of Prop *)
+Set Positivity Checking.
 
+Unset Guard Checking.
 Fixpoint rep_ind (R : Rou -> list (list nat) -> Prop)(HypO: R Over [])
          (HypN: forall (f: (Rou -> list nat) -> list nat)(l: list nat)(ll: list(list nat)), (forall (k: Rou -> list nat)(ll': list(list nat)), isextractor R ll' k -> f k = l ++ flatten(zip ll' ll)) -> R (Next f) (l::ll)) (c : Rou) (l : list (list nat))(Hyp: rep c l) {struct Hyp}: R c l :=
   match Hyp in (rep c0 l0) return (R c0 l0) with

--- a/coq/BreadthFirst.v
+++ b/coq/BreadthFirst.v
@@ -3,7 +3,8 @@ Simon Boulier (INRIA) for the part before the def. of γ (without the simple lem
 Ralph Matthes (IRIT - CNRS and Univ. of Toulouse) for the three different methods of verification, all suggested in 1995 and for the forest-based verification and new system view found in 2018
 
 occasional references are made to the paper "Martin Hofmann’s case for non-strictly positive
-data types" by U. Berger, R. Matthes and A. Setzer, in LIPIcs vol. 130 (TYPES 2018 post-proceedings), https://doi.org/10.4230/LIPIcs.TYPES.2018.1
+data types" by U. Berger, R. Matthes and A. Setzer, in LIPIcs vol. 130 (TYPES 2018 post-proceedings),
+https://doi.org/10.4230/LIPIcs.TYPES.2018.1
 
 *)
 

--- a/coq/READMECoq.txt
+++ b/coq/READMECoq.txt
@@ -1,14 +1,14 @@
-Since Coq 8.11, one can selectively switch off positivity checks. This is used in important ways in the code for BreadthFirst.v (tested with Coq 8.13.2, compiled with OCaml 4.10.0).
+Since Coq 8.11, one can selectively switch off positivity and guardedness checks. This is used in important ways in the code for BreadthFirst.v (tested with Coq 8.13.2, compiled with OCaml 4.10.0).
 
-[ historic comments ]
+[ historic comments:
 
 in previous versions, the code in BreadthFirst.v depended on the TypingFlags plugin by Simon Boulier
 
 https://github.com/SimonBoulier/TypingFlags
 
-One has to compile it and to *install* it, usually the latter with sudo make install or make install, depending on the system configuration.
+One had to compile it and to *install* it, usually the latter with sudo make install or make install, depending on the system configuration.
 
-Then, one can compile the .v file with coqc without further options or just use ProofGeneral to study it interactively.
+Then, one could compile the .v file with coqc without further options or just use ProofGeneral to study it interactively.
 
 (tested again with Coq 8.9.0, compiled with OCaml 4.07.0;
  tested again with Coq 8.9.1, compiled with OCaml 4.07.1)

--- a/coq/READMECoq.txt
+++ b/coq/READMECoq.txt
@@ -1,4 +1,8 @@
-the code in BreadthFirst.v depends on the TypingFlags plugin by Simon Boulier
+Since Coq 8.11, one can selectively switch off positivity checks. This is used in important ways in the code for BreadthFirst.v (tested with Coq 8.13.2, compiled with OCaml 4.10.0).
+
+[ historic comments ]
+
+in previous versions, the code in BreadthFirst.v depended on the TypingFlags plugin by Simon Boulier
 
 https://github.com/SimonBoulier/TypingFlags
 
@@ -8,3 +12,4 @@ Then, one can compile the .v file with coqc without further options or just use 
 
 (tested again with Coq 8.9.0, compiled with OCaml 4.07.0;
  tested again with Coq 8.9.1, compiled with OCaml 4.07.1)
+ ]


### PR DESCRIPTION
the instructions become trivial, the source code is only changed minimally, with the imposed separation of positivity and guardedness checking